### PR TITLE
feat: Changed image to the eclipsevolttron aems image

### DIFF
--- a/aems-edge/configurations/docker/docker-compose-aems.yml
+++ b/aems-edge/configurations/docker/docker-compose-aems.yml
@@ -8,7 +8,7 @@ services:
       dockerfile: Dockerfile-aems
       args:
         install_rmq: 'false'
-    image: natet/volttron-aems:v-docker-dev-aems
+    image: eclipsevolttron/volttron-aems:latest
     network_mode: host
     volumes:
       - ./platform_config.yml:/platform_config.yml


### PR DESCRIPTION
Volttron-aems image is now pushed to eclipsevolttron. Use this image now instead of the one in natet.